### PR TITLE
Fix typo "Duplciate" -> "Duplicate"

### DIFF
--- a/src/receipts/receipt-form/receipt-form.component.html
+++ b/src/receipts/receipt-form/receipt-form.component.html
@@ -204,7 +204,7 @@
 >{{ option.name }}
 </ng-template>
 
-<ng-template #successDuplciateSnackbar>
+<ng-template #successDuplicateSnackbar>
   <div class="d-flex justify-content-end align-items-center">
     <span class="me-4">
       Receipt successfully duplicated. Click navigate to view duplicated

--- a/src/receipts/receipt-form/receipt-form.component.ts
+++ b/src/receipts/receipt-form/receipt-form.component.ts
@@ -50,8 +50,8 @@ export class ReceiptFormComponent implements OnInit {
   @ViewChild("paidByAutocomplete")
   public paidByAutocomplete!: UserAutocompleteComponent;
 
-  @ViewChild("successDuplciateSnackbar")
-  public successDuplciateSnackbar!: TemplateRef<any>;
+  @ViewChild("successDuplicateSnackbar")
+  public successDuplicateSnackbar!: TemplateRef<any>;
 
   @ViewChild("quickActionsDialog")
   public quickActionsDialog!: TemplateRef<any>;
@@ -489,7 +489,7 @@ export class ReceiptFormComponent implements OnInit {
         tap((r: Receipt) => {
           this.duplicatedReceiptId = r.id.toString();
           this.duplicatedSnackbarRef = this.snackbarService.successFromTemplate(
-            this.successDuplciateSnackbar,
+            this.successDuplicateSnackbar,
             { duration: 8000 }
           );
         })

--- a/src/receipts/receipts-table/receipts-table.component.html
+++ b/src/receipts/receipts-table/receipts-table.component.html
@@ -134,7 +134,7 @@
     <app-button
       matButtonType="iconButton"
       icon="file_copy"
-      tooltip="Duplciate"
+      tooltip="Duplicate"
       color="accent"
       (clicked)="duplicateReceipt(element.id)"
     ></app-button>


### PR DESCRIPTION
Fixed this typo that I spotted in a tooltip.
Haven't tried it but should be simple enough.