### PR TITLE
Add linked items support for receipt item sharing

### DIFF
--- a/src/open-api/model/item.ts
+++ b/src/open-api/model/item.ts
@@ -41,6 +41,10 @@ export interface Item {
     receiptId: number;
     status: ItemStatus;
     /**
+     * Foreign key to link this item to another item (for sharing)
+     */
+    linkedItemId?: number;
+    /**
      * Categories associated to the item
      */
     categories?: Array<Category>;

--- a/src/open-api/model/item.ts
+++ b/src/open-api/model/item.ts
@@ -41,9 +41,9 @@ export interface Item {
     receiptId: number;
     status: ItemStatus;
     /**
-     * Foreign key to link this item to another item (for sharing)
+     * Items linked to this item (for sharing)
      */
-    linkedItemId?: number;
+    linkedItems?: Array<Item>;
     /**
      * Categories associated to the item
      */

--- a/src/open-api/model/upsertItemCommand.ts
+++ b/src/open-api/model/upsertItemCommand.ts
@@ -31,6 +31,10 @@ export interface UpsertItemCommand {
     receiptId: number;
     status: ItemStatus;
     /**
+     * Foreign key to link this item to another item (for sharing)
+     */
+    linkedItemId?: number;
+    /**
      * Categories associated to item
      */
     categories?: Array<UpsertCategoryCommand>;

--- a/src/open-api/model/upsertItemCommand.ts
+++ b/src/open-api/model/upsertItemCommand.ts
@@ -31,10 +31,6 @@ export interface UpsertItemCommand {
     receiptId: number;
     status: ItemStatus;
     /**
-     * Foreign key to link this item to another item (for sharing)
-     */
-    linkedItemId?: number;
-    /**
      * Categories associated to item
      */
     categories?: Array<UpsertCategoryCommand>;
@@ -42,6 +38,10 @@ export interface UpsertItemCommand {
      * Tags associated to item
      */
     tags?: Array<UpsertTagCommand>;
+    /**
+     * Items linked to this item (for sharing) - one level deep only
+     */
+    linkedItems?: Array<UpsertItemCommand>;
 }
 export namespace UpsertItemCommand {
 }

--- a/src/receipts/item-add-form/item-add-form.component.ts
+++ b/src/receipts/item-add-form/item-add-form.component.ts
@@ -93,6 +93,7 @@ export class ItemAddFormComponent implements OnInit, OnDestroy {
     this.newItemFormGroup = buildItemForm(
       undefined,
       this.receiptId,
+      false,
       false
     );
   }

--- a/src/receipts/item-list/item-list.component.html
+++ b/src/receipts/item-list/item-list.component.html
@@ -16,7 +16,7 @@
 
   <!-- No Items Message -->
   @if (items.length === 0 && mode === formMode.view && !isAdding) {
-    <div class="no-items-message">No items for this receipt</div>
+    <div>No items for this receipt</div>
   }
 
   <!-- Items List -->

--- a/src/receipts/item-list/item-list.component.html
+++ b/src/receipts/item-list/item-list.component.html
@@ -48,6 +48,15 @@
             <div content class="d-flex flex-column item-form-container">
               <div class="d-flex justify-content-end">
                 @if (!(mode | inputReadonly)) {
+                  <app-button
+                    matButtonType="iconButton"
+                    icon="call_split"
+                    tooltip="Split Item"
+                    [disabled]="
+                      !(originalReceipt?.groupId | groupRole : groupRole.Editor)
+                    "
+                    (clicked)="splitItem(itemData)"
+                  ></app-button>
                   <app-delete-button
                     tooltip="Remove Item"
                     [disabled]="

--- a/src/receipts/item-list/item-list.component.scss
+++ b/src/receipts/item-list/item-list.component.scss
@@ -45,15 +45,6 @@ app-item-list {
     }
   }
 
-
-  // No Items Message
-  .no-items-message {
-    text-align: center;
-    padding: 40px;
-    color: #666;
-    font-style: italic;
-  }
-
   // Items List
   .item-form-container:nth-child(even) {
     background-color: #efefef;

--- a/src/receipts/quick-actions-dialog/quick-actions-dialog.component.spec.ts
+++ b/src/receipts/quick-actions-dialog/quick-actions-dialog.component.spec.ts
@@ -50,6 +50,7 @@ describe("QuickActionsDialogComponent", () => {
       receiptItems: new FormArray([]),
     });
     component.originalReceipt = { id: 1 } as any;
+    component.amountToSplit = 100; // Set the amount to split
     fixture.detectChanges();
 
     // Reset mocks
@@ -91,6 +92,7 @@ describe("QuickActionsDialogComponent", () => {
       amount: new FormControl("100"),
       receiptItems: new FormArray([]),
     });
+    component.amountToSplit = 100;
     component.ngOnInit();
 
     const users = [
@@ -125,6 +127,7 @@ describe("QuickActionsDialogComponent", () => {
       amount: new FormControl("100"),
       receiptItems: new FormArray([]),
     });
+    component.amountToSplit = 100;
     component.ngOnInit();
 
     const formArray = component.localForm.get("usersToSplit") as FormArray;
@@ -498,6 +501,7 @@ describe("QuickActionsDialogComponent", () => {
     describe("Edge Cases", () => {
       it("should handle receipt amount of 0", () => {
         component.parentForm.get("amount")?.setValue("0");
+        component.amountToSplit = 0;
         component.localForm.patchValue({
           quickAction: component.radioValues[2].value,
         });
@@ -508,12 +512,13 @@ describe("QuickActionsDialogComponent", () => {
         component.addSplits();
 
         expect(mockSnackbarService.error).toHaveBeenCalledWith(
-          "Receipt amount does not exist or is invalid!"
+          "Amount to split does not exist or is invalid!"
         );
       });
 
       it("should handle invalid receipt amount", () => {
         component.parentForm.get("amount")?.setValue("invalid");
+        component.amountToSplit = NaN;
         component.localForm.patchValue({
           quickAction: component.radioValues[2].value,
         });
@@ -524,7 +529,7 @@ describe("QuickActionsDialogComponent", () => {
         component.addSplits();
 
         expect(mockSnackbarService.error).toHaveBeenCalledWith(
-          "Receipt amount does not exist or is invalid!"
+          "Amount to split does not exist or is invalid!"
         );
       });
 

--- a/src/receipts/quick-actions-dialog/quick-actions-dialog.component.ts
+++ b/src/receipts/quick-actions-dialog/quick-actions-dialog.component.ts
@@ -1,10 +1,9 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
 import { MatDialogRef } from "@angular/material/dialog";
 import { RadioButtonData } from "src/radio-group/models";
 import { Item, Receipt, User } from "../../open-api";
 import { SnackbarService } from "../../services/index";
-import { buildItemForm } from "../utils/form.utils";
 
 enum QuickActions {
   "SplitEvenly" = "Split Evenly",
@@ -23,11 +22,11 @@ export class QuickActionsDialogComponent implements OnInit {
 
   @Input() public usersToOmit: string[] = [];
 
-  @Input() public parentForm!: FormGroup;
-
   @Input() public amountToSplit!: number;
 
   @Input() public itemIndex?: number;
+
+  @Output() public itemsToAdd = new EventEmitter<{ items: Item[], itemIndex?: number }>();
 
   public localForm: FormGroup = new FormGroup({});
 
@@ -46,27 +45,6 @@ export class QuickActionsDialogComponent implements OnInit {
 
   private get usersFormArray(): FormArray {
     return this.localForm.get("usersToSplit") as FormArray;
-  }
-
-  private get receiptItems(): FormArray {
-    return this.parentForm.get("receiptItems") as FormArray;
-  }
-
-  private get targetItemsArray(): FormArray {
-    if (this.itemIndex !== undefined) {
-      // We're splitting an item, so add to its linkedItems
-      const itemFormGroup = this.receiptItems.at(this.itemIndex) as FormGroup;
-      let linkedItems = itemFormGroup.get("linkedItems") as FormArray;
-      if (!linkedItems) {
-        // Create linkedItems FormArray if it doesn't exist
-        linkedItems = this.formBuilder.array([]);
-        itemFormGroup.addControl("linkedItems", linkedItems);
-      }
-      return linkedItems;
-    } else {
-      // We're splitting a receipt, so add to receiptItems
-      return this.receiptItems;
-    }
   }
 
   constructor(
@@ -184,25 +162,31 @@ export class QuickActionsDialogComponent implements OnInit {
     }
 
     if (this.localForm.valid) {
+      let items: Item[] = [];
+
       if (
         this.localForm.get("quickAction")?.value === this.radioValues[0].value
       ) {
-        this.addEvenSplitItems();
+        items = this.addEvenSplitItems();
       } else if (
         this.localForm.get("quickAction")?.value === this.radioValues[1].value
       ) {
-        this.splitEvenlyWithOptionalParts();
+        items = this.splitEvenlyWithOptionalParts();
       } else if (
         this.localForm.get("quickAction")?.value === this.radioValues[2].value
       ) {
-        this.splitByPercentage();
+        items = this.splitByPercentage();
       }
+
+      // Emit the items to be added
+      this.itemsToAdd.emit({ items, itemIndex: this.itemIndex });
       this.dialogRef.close(true);
     }
   }
 
-  private addEvenSplitItems(): void {
+  private addEvenSplitItems(): Item[] {
     const users: User[] = this.usersFormArray.controls.map((c) => c.value);
+    const items: Item[] = [];
 
     users.forEach((u) => {
       const item = this.buildSplitItem(
@@ -210,19 +194,16 @@ export class QuickActionsDialogComponent implements OnInit {
         `${u.displayName}'s Even Portion`,
         Number.parseFloat((this.amountToSplit / users.length).toFixed(2))
       );
-
-      const formGroup = buildItemForm(
-        item,
-        this.originalReceipt?.id?.toString(),
-        true
-      );
-      this.targetItemsArray.push(formGroup);
+      items.push(item);
     });
+
+    return items;
   }
 
-  private splitEvenlyWithOptionalParts(): void {
+  private splitEvenlyWithOptionalParts(): Item[] {
     let amount = this.amountToSplit;
     const users: User[] = this.usersFormArray.value;
+    const items: Item[] = [];
 
     // Build optional parts first
     users.forEach((u) => {
@@ -236,13 +217,7 @@ export class QuickActionsDialogComponent implements OnInit {
           `${u.displayName}'s Portion`,
           this.localForm.get(u.id.toString())?.value
         );
-        const formGroup = buildItemForm(
-          item,
-          this.originalReceipt?.id?.toString(),
-          true
-        );
-
-        this.receiptItems.push(formGroup);
+        items.push(item);
       }
     });
 
@@ -254,14 +229,10 @@ export class QuickActionsDialogComponent implements OnInit {
         `${u.displayName}'s Even Portion`,
         Number.parseFloat((amount / users2.length).toFixed(2))
       );
-
-      const formGroup = buildItemForm(
-        item,
-        this.originalReceipt?.id?.toString(),
-        true
-      );
-      this.targetItemsArray.push(formGroup);
+      items.push(item);
     });
+
+    return items;
   }
 
   private buildSplitItem(u: User, name: string, amount: number): Item {
@@ -313,9 +284,10 @@ export class QuickActionsDialogComponent implements OnInit {
     return true;
   }
 
-  private splitByPercentage(): void {
+  private splitByPercentage(): Item[] {
     const users: User[] = this.usersFormArray.value;
     const receiptAmount = this.amountToSplit;
+    const items: Item[] = [];
 
     users.forEach((user) => {
       const percentage = Number.parseFloat(
@@ -329,15 +301,11 @@ export class QuickActionsDialogComponent implements OnInit {
           `${user.displayName}'s ${percentage}% Portion`,
           amount
         );
-
-        const formGroup = buildItemForm(
-          item,
-          this.originalReceipt?.id?.toString(),
-          true
-        );
-        this.receiptItems.push(formGroup);
+        items.push(item);
       }
     });
+
+    return items;
   }
 
   public setPercentage(userId: string, percentage: number): void {

--- a/src/receipts/quick-actions-dialog/quick-actions-dialog.component.ts
+++ b/src/receipts/quick-actions-dialog/quick-actions-dialog.component.ts
@@ -241,6 +241,8 @@ export class QuickActionsDialogComponent implements OnInit {
       chargedToUserId: u.id,
       receiptId: this.originalReceipt?.id,
       amount: amount,
+      categories: [],
+      tags: []
     } as any as Item;
   }
 

--- a/src/receipts/receipt-form/receipt-form.component.html
+++ b/src/receipts/receipt-form/receipt-form.component.html
@@ -263,6 +263,7 @@
     [parentForm]="form"
     [originalReceipt]="originalReceipt"
     [usersToOmit]="usersToOmit"
+    [amountToSplit]="form.get('amount')?.value || 0"
   ></app-quick-actions-dialog>
 </ng-template>
 

--- a/src/receipts/receipt-form/receipt-form.component.html
+++ b/src/receipts/receipt-form/receipt-form.component.html
@@ -161,6 +161,7 @@
           [triggerAddMode]="triggerItemListAddMode"
           (itemAdded)="onItemAdded($event)"
           (itemRemoved)="onItemRemoved($event)"
+          (itemSplit)="onItemSplit($event)"
         ></app-item-list>
       </app-form-section>
       <app-form-section

--- a/src/receipts/receipt-form/receipt-form.component.html
+++ b/src/receipts/receipt-form/receipt-form.component.html
@@ -260,10 +260,10 @@
     cdkDrag
     cdkDragHandle
     cdkDragRootElement=".cdk-overlay-pane"
-    [parentForm]="form"
     [originalReceipt]="originalReceipt"
     [usersToOmit]="usersToOmit"
     [amountToSplit]="form.get('amount')?.value || 0"
+    (itemsToAdd)="onQuickActionItemsAdded($event)"
   ></app-quick-actions-dialog>
 </ng-template>
 

--- a/src/receipts/receipt-form/receipt-form.component.ts
+++ b/src/receipts/receipt-form/receipt-form.component.ts
@@ -704,6 +704,43 @@ export class ReceiptFormComponent implements OnInit {
     }
   }
 
+  public onQuickActionItemsAdded(data: { items: Item[], itemIndex?: number }): void {
+    const { items, itemIndex } = data;
+
+    if (itemIndex !== undefined) {
+      // Adding items as linkedItems to an existing item
+      const targetItemFormGroup = this.receiptItemsFormArray.at(itemIndex) as FormGroup;
+      let linkedItemsArray = targetItemFormGroup.get("linkedItems") as FormArray;
+      
+      if (!linkedItemsArray) {
+        // Create linkedItems FormArray if it doesn't exist
+        linkedItemsArray = this.formBuilder.array([]);
+        targetItemFormGroup.addControl("linkedItems", linkedItemsArray);
+      }
+
+      // Add each item to the linkedItems array
+      items.forEach(item => {
+        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true);
+        linkedItemsArray.push(newFormGroup);
+      });
+    } else {
+      // Adding items as regular receipt items
+      items.forEach(item => {
+        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true);
+        this.receiptItemsFormArray.push(newFormGroup);
+      });
+    }
+
+    // Refresh component views
+    this.shareListComponent?.setUserItemMap();
+    this.itemListComponent?.setItems();
+
+    // Auto-sync amount if enabled
+    if (this.syncAmountWithItems) {
+      this.updateAmountFromItems();
+    }
+  }
+
   public onAllItemsResolved(userId: string): void {
     // The actual item status updates are handled by the child component
     // We don't need to do anything here as the form will reflect the changes

--- a/src/receipts/receipt-form/receipt-form.component.ts
+++ b/src/receipts/receipt-form/receipt-form.component.ts
@@ -717,8 +717,19 @@ export class ReceiptFormComponent implements OnInit {
     }
   }
 
-  public onItemRemoved(data: { item: Item; arrayIndex: number }): void {
-    this.receiptItemsFormArray.removeAt(data.arrayIndex);
+  public onItemRemoved(data: { item: Item; arrayIndex: number; isLinkedItem?: boolean; linkedItemIndex?: number }): void {
+    if (data.isLinkedItem && data.linkedItemIndex !== undefined) {
+      // Remove linked item from parent's linkedItems array
+      const parentItemFormGroup = this.receiptItemsFormArray.at(data.arrayIndex) as FormGroup;
+      const linkedItemsArray = parentItemFormGroup.get("linkedItems") as FormArray;
+      if (linkedItemsArray && data.linkedItemIndex < linkedItemsArray.length) {
+        linkedItemsArray.removeAt(data.linkedItemIndex);
+      }
+    } else {
+      // Remove regular item from main receiptItems array
+      this.receiptItemsFormArray.removeAt(data.arrayIndex);
+    }
+    
     this.shareListComponent.setUserItemMap();
     this.itemListComponent.setItems();
 

--- a/src/receipts/receipt-form/receipt-form.component.ts
+++ b/src/receipts/receipt-form/receipt-form.component.ts
@@ -337,7 +337,7 @@ export class ReceiptFormComponent implements OnInit {
       receiptItems: this.formBuilder.array(
         this.originalReceipt?.receiptItems
           ? this.originalReceipt.receiptItems.map((item) =>
-            buildItemForm(item, this.originalReceipt?.id?.toString(), !!item.chargedToUserId)
+            buildItemForm(item, this.originalReceipt?.id?.toString(), !!item.chargedToUserId, false)
           )
           : []
       )
@@ -682,7 +682,7 @@ export class ReceiptFormComponent implements OnInit {
   }
 
   public onItemAdded(item: Item): void {
-    const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), !!item.chargedToUserId);
+    const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), !!item.chargedToUserId, this.syncAmountWithItems);
     this.receiptItemsFormArray.push(newFormGroup);
     this.shareListComponent.setUserItemMap();
     this.itemListComponent.setItems();
@@ -720,13 +720,13 @@ export class ReceiptFormComponent implements OnInit {
 
       // Add each item to the linkedItems array
       items.forEach(item => {
-        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true);
+        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true, this.syncAmountWithItems);
         linkedItemsArray.push(newFormGroup);
       });
     } else {
       // Adding items as regular receipt items
       items.forEach(item => {
-        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true);
+        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true, this.syncAmountWithItems);
         this.receiptItemsFormArray.push(newFormGroup);
       });
     }

--- a/src/receipts/receipt-form/receipt-form.component.ts
+++ b/src/receipts/receipt-form/receipt-form.component.ts
@@ -743,21 +743,7 @@ export class ReceiptFormComponent implements OnInit {
     const { items, itemIndex } = data;
 
     if (itemIndex !== undefined) {
-      // Adding items as linkedItems to an existing item
-      const targetItemFormGroup = this.receiptItemsFormArray.at(itemIndex) as FormGroup;
-      let linkedItemsArray = targetItemFormGroup.get("linkedItems") as FormArray;
-
-      if (!linkedItemsArray) {
-        // Create linkedItems FormArray if it doesn't exist
-        linkedItemsArray = this.formBuilder.array([]);
-        targetItemFormGroup.addControl("linkedItems", linkedItemsArray);
-      }
-
-      // Add each item to the linkedItems array
-      items.forEach(item => {
-        const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true, this.syncAmountWithItems);
-        linkedItemsArray.push(newFormGroup);
-      });
+      this.addLinkedItems(items, itemIndex);
     } else {
       // Adding items as regular receipt items
       items.forEach(item => {
@@ -766,19 +752,16 @@ export class ReceiptFormComponent implements OnInit {
       });
     }
 
-    // Refresh component views
-    this.shareListComponent?.setUserItemMap();
-    this.itemListComponent?.setItems();
-
-    // Auto-sync amount if enabled
-    if (this.syncAmountWithItems) {
-      this.updateAmountFromItems();
-    }
+    this.refreshComponentsAndSync();
   }
 
   public onItemSplit(data: { items: Item[], itemIndex: number }): void {
     const { items, itemIndex } = data;
+    this.addLinkedItems(items, itemIndex);
+    this.refreshComponentsAndSync();
+  }
 
+  private addLinkedItems(items: Item[], itemIndex: number): void {
     // Adding items as linkedItems to an existing item
     const targetItemFormGroup = this.receiptItemsFormArray.at(itemIndex) as FormGroup;
     let linkedItemsArray = targetItemFormGroup.get("linkedItems") as FormArray;
@@ -786,7 +769,7 @@ export class ReceiptFormComponent implements OnInit {
     if (!linkedItemsArray) {
       // Create linkedItems FormArray if it doesn't exist
       linkedItemsArray = this.formBuilder.array([]);
-      (targetItemFormGroup as any).addControl("linkedItems", linkedItemsArray);
+      targetItemFormGroup.addControl("linkedItems", linkedItemsArray);
     }
 
     // Add each item to the linkedItems array
@@ -794,7 +777,9 @@ export class ReceiptFormComponent implements OnInit {
       const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true, this.syncAmountWithItems);
       linkedItemsArray.push(newFormGroup);
     });
+  }
 
+  private refreshComponentsAndSync(): void {
     // Refresh component views
     this.shareListComponent?.setUserItemMap();
     this.itemListComponent?.setItems();
@@ -909,7 +894,6 @@ export class ReceiptFormComponent implements OnInit {
   }
 
   private updateReceipt(): void {
-    console.log(this.form.value, " value");
     this.receiptService
       .updateReceipt(this.originalReceipt?.id as number, this.form.value)
       .pipe(

--- a/src/receipts/receipt-form/receipt-form.component.ts
+++ b/src/receipts/receipt-form/receipt-form.component.ts
@@ -765,6 +765,35 @@ export class ReceiptFormComponent implements OnInit {
     }
   }
 
+  public onItemSplit(data: { items: Item[], itemIndex: number }): void {
+    const { items, itemIndex } = data;
+
+    // Adding items as linkedItems to an existing item
+    const targetItemFormGroup = this.receiptItemsFormArray.at(itemIndex) as FormGroup;
+    let linkedItemsArray = targetItemFormGroup.get("linkedItems") as FormArray;
+
+    if (!linkedItemsArray) {
+      // Create linkedItems FormArray if it doesn't exist
+      linkedItemsArray = this.formBuilder.array([]);
+      (targetItemFormGroup as any).addControl("linkedItems", linkedItemsArray);
+    }
+
+    // Add each item to the linkedItems array
+    items.forEach(item => {
+      const newFormGroup = buildItemForm(item, this.originalReceipt?.id?.toString(), true, this.syncAmountWithItems);
+      linkedItemsArray.push(newFormGroup);
+    });
+
+    // Refresh component views
+    this.shareListComponent?.setUserItemMap();
+    this.itemListComponent?.setItems();
+
+    // Auto-sync amount if enabled
+    if (this.syncAmountWithItems) {
+      this.updateAmountFromItems();
+    }
+  }
+
   public onAllItemsResolved(userId: string): void {
     // The actual item status updates are handled by the child component
     // We don't need to do anything here as the form will reflect the changes
@@ -869,6 +898,7 @@ export class ReceiptFormComponent implements OnInit {
   }
 
   private updateReceipt(): void {
+    console.log(this.form.value, " value");
     this.receiptService
       .updateReceipt(this.originalReceipt?.id as number, this.form.value)
       .pipe(

--- a/src/receipts/share-list/share-list.component.html
+++ b/src/receipts/share-list/share-list.component.html
@@ -104,6 +104,15 @@
         cardStyle="mb-2"
       >
         <div content class="d-flex flex-column item-form-container">
+          @if (itemData.isLinkedItem && itemData.parentItem) {
+            <div class="d-flex align-items-center mb-2 p-2 bg-light border-start border-primary">
+              <mat-icon class="me-2 text-primary">link</mat-icon>
+              <small class="text-muted">
+                Split from: <strong>{{ itemData.parentItem.name }}</strong> 
+                ({{ itemData.parentItem.amount | customCurrency }})
+              </small>
+            </div>
+          }
           <div class="d-flex justify-content-end">
             @if (!(mode | inputReadonly)) {
               <app-delete-button
@@ -121,9 +130,7 @@
               #nameField
               label="Name"
               [inputId]="'name-' + i"
-              [inputFormControl]="
-              form | formGet : 'receiptItems.' + itemData.arrayIndex + '.name'
-            "
+              [inputFormControl]="form | formGet : getFormControlPath(itemData, 'name')"
               [readonly]="mode | inputReadonly"
               (inputBlur)="addInlineItemOnBlur(key, i)"
             >
@@ -132,9 +139,7 @@
               class="col"
               label="Amount"
               [isCurrency]="true"
-              [inputFormControl]="
-              form | formGet : 'receiptItems.' + itemData.arrayIndex + '.amount'
-            "
+              [inputFormControl]="form | formGet : getFormControlPath(itemData, 'amount')"
               [readonly]="mode | inputReadonly"
               (inputBlur)="addInlineItemOnBlur(key, i)"
             >
@@ -144,9 +149,7 @@
               label="Status"
               optionValueKey="value"
               optionDisplayKey="displayValue"
-              [inputFormControl]="
-              form | formGet : 'receiptItems.' + itemData.arrayIndex + '.status'
-            "
+              [inputFormControl]="form | formGet : getFormControlPath(itemData, 'status')"
               [readonly]="mode | inputReadonly"
               [options]="itemStatusOptions"
               (inputBlur)="addInlineItemOnBlur(key, i)"
@@ -155,7 +158,7 @@
             @if (!selectedGroup?.groupReceiptSettings?.hideShareCategories) {
               <app-category-autocomplete
                 [categories]="categories"
-                [inputFormControl]="form | formGet : 'receiptItems.' + itemData.arrayIndex + '.categories'"
+                [inputFormControl]="form | formGet : getFormControlPath(itemData, 'categories')"
                 [readonly]="mode | inputReadonly"
               ></app-category-autocomplete>
             }
@@ -163,7 +166,7 @@
             @if (!selectedGroup?.groupReceiptSettings?.hideShareTags) {
               <app-tag-autocomplete
                 [tags]="tags"
-                [inputFormControl]="form | formGet : 'receiptItems.' + itemData.arrayIndex + '.tags'"
+                [inputFormControl]="form | formGet : getFormControlPath(itemData, 'tags')"
                 [readonly]="mode | inputReadonly"
               ></app-tag-autocomplete>
             }

--- a/src/receipts/share-list/share-list.component.spec.ts
+++ b/src/receipts/share-list/share-list.component.spec.ts
@@ -70,7 +70,7 @@ describe("ShareListComponent", () => {
 
   function createFormWithItems(items: Item[]): FormGroup {
     const receiptItems = new FormArray(
-      items.map(item => buildItemForm(item, mockReceipt.id?.toString(), true))
+      items.map(item => buildItemForm(item, mockReceipt.id?.toString(), true, false))
     );
 
     return new FormGroup({
@@ -906,7 +906,8 @@ describe("ShareListComponent", () => {
       const newItem = buildItemForm(
         { id: 5, name: "New Item", amount: "20.00", chargedToUserId: 4, status: ItemStatus.Open, receiptId: 1 } as Item,
         "1",
-        true
+        true,
+        false
       );
       (component.receiptItems as FormArray).push(newItem);
 

--- a/src/receipts/share-list/share-list.component.spec.ts
+++ b/src/receipts/share-list/share-list.component.spec.ts
@@ -480,7 +480,9 @@ describe("ShareListComponent", () => {
 
       expect(component.itemRemoved.emit).toHaveBeenCalledWith({
         item: mockItems[0],
-        arrayIndex: 0
+        arrayIndex: 0,
+        isLinkedItem: undefined,
+        linkedItemIndex: undefined
       });
     });
 
@@ -620,7 +622,9 @@ describe("ShareListComponent", () => {
           chargedToUserId: 1,
           status: ItemStatus.Open
         }),
-        arrayIndex: 1
+        arrayIndex: 1,
+        isLinkedItem: undefined,
+        linkedItemIndex: undefined
       });
     });
 
@@ -649,7 +653,9 @@ describe("ShareListComponent", () => {
           chargedToUserId: 1,
           status: ItemStatus.Open
         }),
-        arrayIndex: 1
+        arrayIndex: 1,
+        isLinkedItem: undefined,
+        linkedItemIndex: undefined
       });
     });
 

--- a/src/receipts/share-list/share-list.component.ts
+++ b/src/receipts/share-list/share-list.component.ts
@@ -258,6 +258,10 @@ export class ShareListComponent implements OnInit, OnChanges {
   }
 
   public getFormControlPath(itemData: ItemData, fieldName: string): string {
+    if (!itemData || !fieldName) {
+      return '';
+    }
+    
     if (itemData.isLinkedItem && itemData.linkedItemIndex !== undefined) {
       // For linkedItems: receiptItems.parentIndex.linkedItems.linkedIndex.fieldName
       return `receiptItems.${itemData.arrayIndex}.linkedItems.${itemData.linkedItemIndex}.${fieldName}`;

--- a/src/receipts/share-list/share-list.component.ts
+++ b/src/receipts/share-list/share-list.component.ts
@@ -60,7 +60,7 @@ export class ShareListComponent implements OnInit, OnChanges {
 
   @Output() public itemAdded = new EventEmitter<Item>();
 
-  @Output() public itemRemoved = new EventEmitter<{ item: Item; arrayIndex: number }>();
+  @Output() public itemRemoved = new EventEmitter<{ item: Item; arrayIndex: number; isLinkedItem?: boolean; linkedItemIndex?: number }>();
 
   @Output() public allItemsResolved = new EventEmitter<string>();
 
@@ -177,7 +177,12 @@ export class ShareListComponent implements OnInit, OnChanges {
   }
 
   public removeItem(itemData: ItemData): void {
-    this.itemRemoved.emit({ item: itemData.item, arrayIndex: itemData.arrayIndex });
+    this.itemRemoved.emit({ 
+      item: itemData.item, 
+      arrayIndex: itemData.arrayIndex,
+      isLinkedItem: itemData.isLinkedItem,
+      linkedItemIndex: itemData.linkedItemIndex
+    });
   }
 
   public addInlineItem(userId: string, event?: MouseEvent): void {
@@ -216,7 +221,12 @@ export class ShareListComponent implements OnInit, OnChanges {
         const amountValue = formGroup.get("amount")?.value;
 
         if (formGroup.pristine && (!nameValue || nameValue.trim() === "") && (!amountValue || amountValue === 0)) {
-          this.itemRemoved.emit({ item: lastItem.item, arrayIndex: lastItem.arrayIndex });
+          this.itemRemoved.emit({ 
+            item: lastItem.item, 
+            arrayIndex: lastItem.arrayIndex,
+            isLinkedItem: lastItem.isLinkedItem,
+            linkedItemIndex: lastItem.linkedItemIndex
+          });
         }
       }
     }

--- a/src/receipts/share-list/share-list.component.ts
+++ b/src/receipts/share-list/share-list.component.ts
@@ -132,7 +132,8 @@ export class ShareListComponent implements OnInit, OnChanges {
     this.newItemFormGroup = buildItemForm(
       undefined,
       this.originalReceipt?.id?.toString(),
-      true
+      true,
+      false
     );
   }
 

--- a/src/receipts/utils/form.utils.ts
+++ b/src/receipts/utils/form.utils.ts
@@ -1,7 +1,7 @@
 import { AbstractControl, FormArray, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from "@angular/forms";
 import { Item, ItemStatus } from "../../open-api";
 
-export function buildItemForm(item?: Item, receiptId?: string, isShare: boolean = true): FormGroup {
+export function buildItemForm(item?: Item, receiptId?: string, isShare: boolean = true, syncAmountWithItems: boolean = false): FormGroup {
   const formGroup = new FormGroup({
     name: new FormControl(item?.name ?? "", Validators.required),
     chargedToUserId: new FormControl(item?.chargedToUserId ?? undefined, []),
@@ -9,7 +9,7 @@ export function buildItemForm(item?: Item, receiptId?: string, isShare: boolean 
     amount: new FormControl(item?.amount ?? undefined, [
       Validators.required,
       Validators.min(0),
-      itemTotalValidator(isShare),
+      itemTotalValidator(isShare, syncAmountWithItems),
     ]),
     isTaxed: new FormControl(item?.IsTaxed ?? false),
     categories: new FormArray(item?.categories?.map((c) => new FormControl(c)) ?? []),
@@ -27,8 +27,13 @@ export function buildItemForm(item?: Item, receiptId?: string, isShare: boolean 
   return formGroup;
 }
 
-function itemTotalValidator(isShare: boolean): ValidatorFn {
+function itemTotalValidator(isShare: boolean, syncAmountWithItems: boolean = false): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
+    // Skip validation if sync with items is enabled - the receipt total will adjust automatically
+    if (syncAmountWithItems) {
+      return null;
+    }
+
     const epsilon = 0.01;
     const errKey = "itemLargerThanTotal";
     const objectName = isShare ? "Share" : "Item";

--- a/src/receipts/utils/form.utils.ts
+++ b/src/receipts/utils/form.utils.ts
@@ -18,6 +18,12 @@ export function buildItemForm(item?: Item, receiptId?: string, isShare: boolean 
       item?.status ?? ItemStatus.Open,
       Validators.required
     ),
+    // Always include linkedItems FormArray, even if empty
+    linkedItems: new FormArray(
+      item?.linkedItems?.map(linkedItem => 
+        buildItemForm(linkedItem, receiptId, true, syncAmountWithItems)
+      ) ?? []
+    ),
   });
 
   if (isShare) {

--- a/src/receipts/utils/form.utils.ts
+++ b/src/receipts/utils/form.utils.ts
@@ -29,8 +29,12 @@ export function buildItemForm(item?: Item, receiptId?: string, isShare: boolean 
 
 function itemTotalValidator(isShare: boolean, syncAmountWithItems: boolean = false): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
-    // Skip validation if sync with items is enabled - the receipt total will adjust automatically
-    if (syncAmountWithItems) {
+    // Check current sync state dynamically from the parent form
+    const parentForm = control?.parent?.parent?.parent;
+    const currentSyncState = parentForm?.get('syncAmountWithItems')?.value ?? syncAmountWithItems;
+    
+    // Skip validation if sync with items is currently enabled - the receipt total will adjust automatically
+    if (currentSyncState) {
       return null;
     }
 


### PR DESCRIPTION
# Changes

- Added support for linking/splitting receipt items across multiple users
- Items can now have nested linkedItems for shared expenses
- Enhanced share list to display and manage both regular and linked items
- Fixed validation and submission issues with linked items
- Improved amount synchronization when items are split